### PR TITLE
Cross-platform paths issue fix

### DIFF
--- a/ffbinaries-lib.js
+++ b/ffbinaries-lib.js
@@ -219,7 +219,7 @@ function downloadUrls(components, urls, opts, callback) {
 
     var zipFilename = url.split('/').pop();
     var binFilenameBase = urlObject.component;
-    var binFilename = getBinaryFilename(binFilenameBase, opts.platform);
+    var binFilename = getBinaryFilename(binFilenameBase, opts.platform || detectPlatform());
     var runningTotal = 0;
     var totalFilesize;
     var interval;

--- a/ffbinaries-lib.js
+++ b/ffbinaries-lib.js
@@ -386,6 +386,7 @@ function locateBinariesSync(components, opts) {
     var result = {
       found: false,
       isExecutable: false,
+      isSystem: false,
       path: null,
       version: null
     };
@@ -398,6 +399,12 @@ function locateBinariesSync(components, opts) {
         if (fse.existsSync(pathToTest)) {
           result.found = true;
           result.path = pathToTest;
+
+          var isOneOfSuggested = suggestedPaths.some(p => p === currentPath);
+
+          if (!isOneOfSuggested) {
+            result.isSystem = true;
+          }
 
           // check if file is executable
           try {

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -331,11 +331,13 @@ describe('ffbinaries library', function () {
       var result = ffbinaries.locateBinariesSync(['ffmpeg', 'ffplay'], { paths: process.cwd() });
       expect(result.ffmpeg).to.exist;
 
-      expect(result.ffplay).to.exist;
-      expect(result.ffplay.found).to.equal(false);
-      expect(result.ffplay.isExecutable).to.equal(false);
-      expect(result.ffplay.path).to.equal(null);
-      expect(result.ffplay.version).to.equal(null);
+      if (!result.ffplay.isSystem) {
+        expect(result.ffplay).to.exist;
+        expect(result.ffplay.found).to.equal(false);
+        expect(result.ffplay.isExecutable).to.equal(false);
+        expect(result.ffplay.path).to.equal(null);
+        expect(result.ffplay.version).to.equal(null);
+      }
     });
   });
 

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -323,8 +323,10 @@ describe('ffbinaries library', function () {
     });
 
     it('should return missing binaries correctly', function () {
-      fs.removeSync(process.cwd() + '/ffplay');
-      fs.removeSync(process.cwd() + '/ffplay.exe');
+      var ffplayPath = path.join(process.cwd(), '/ffplay');
+
+      fs.removeSync(ffplayPath);
+      fs.removeSync(ffplayPath + '.exe');
 
       var result = ffbinaries.locateBinariesSync(['ffmpeg', 'ffplay'], { paths: process.cwd() });
       expect(result.ffmpeg).to.exist;

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -248,7 +248,7 @@ describe('ffbinaries library', function () {
         expect(err).to.equal(null);
         expect(data.length).to.equal(1);
         expect(data[0].filename).to.exist;
-        expect(data[0].status.endsWith('(archive found in cache)')).to.be.ok;
+        expect(data[0].code).to.equal('DONE_FROM_CACHE');
 
         return done();
       });

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -356,8 +356,10 @@ describe('ffbinaries library', function () {
     ];
 
     _.each(removalList, function (filename) {
-      console.log('\x1b[2m- Removing ' + process.cwd() + '/' + filename + '\x1b[0m');
-      fs.removeSync(process.cwd() + '/' + filename);
+      var binPath = path.join(process.cwd(), filename);
+
+      console.log('\x1b[2m- Removing ' + binPath + '\x1b[0m');
+      fs.removeSync(binPath);
     });
   });
 });

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -149,7 +149,7 @@ describe('ffbinaries library', function () {
 
     it('should throw an error for non-existent versions', function (done) {
       ffbinaries.getVersionData('potato', function (err) {
-        expect(err).to.be.ok;
+        expect(err).to.not.be.null;
 
         return done();
       });


### PR DESCRIPTION
## Introduction
I found that on Windows, the module does not work correctly. It loads binaries every time, whether the force flag is set or not. So, I decided to look in the hood of the problem.

> _Quote from **readme.md**_
> 
> Note: you don't need to check for existence of the binaries in the destination folder. ffbinaries will check if the binaries exist first and it will not attempt to re-download them unless you specify {force: true}.

This wasn't working correct on Windows.

###### _P.S - Thanks for this awesome module, it does nice work in our team project 🙂. I wish you creative success in your future projects!_

## What was done to fix the issue

- #### 70b905a05542beb528e814a356243d5cb6e05c89, 2efab4abc65dadb5d9f54225ec504b13b060ba5a - cross-platform paths.
  _If we want a module working on any platform, we need to use `path.join()` or `path.normalize()`. There are more tools to work with this, but these are from the box._

- #### 75d84ce5834e3ce3ecb37bdbe63452fc82a9ce29 - fallback on current platform for `downloadUrls() function`.
  _Function `downloadUrls()` was looking for `opts.platform` and if is not passed, it hasn't any fallback. Setting fallback on current platform calling `detectPlatform()` to avoid null value._

- #### `npm run test` on Windows and MacOS.

## Taking the opportunity to make some fixes too

- #### ec5d0a51daf4d46f87b3bcfcf790533ca772bb1f - `isSystem` flag for `locateBinariesSync()` function
  _Without this flag, test **`"should return missing binaries correctly"`** was breaking when ffmpeg family binaries were installed somewhere in the developer system, as it was in my case. This flag is helpful too in case when the developer wants to know if is system installed bin._

- #### 416f484e8d848b90d4a1195c6ff05edbe59e0b3f, 622ed3b4dc43a3786da4bca3feaebe7eb7d473d4 - invalid tests fixed or optimized.
  _These are **`"should throw an error for non-existent versions"`** and **`"should use cache for repeat requests"`**_